### PR TITLE
Add linux instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To receive it on another
 blecat > myfile.txt
 ```
 
+## Linux
+
+This requires `bluetooth.h` headers in order to build the native component on Linux.
+
+To install on ubuntu, `sudo apt-get install libbluetooth-dev` before `npm install blecat`
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Needs headers to build on linux, added some instructions for Ubuntu in the README

(otherwise you get this when trying to install):

```
> noble@0.3.14 install /home/bryce/boneyard/node_modules/blecat/node_modules/ble-swarm/node_modules/noble
> node-gyp rebuild

make: Entering directory '/home/bryce/boneyard/node_modules/blecat/node_modules/ble-swarm/node_modules/noble/build'
  CC(target) Release/obj.target/hci-ble/src/hci-ble.o
../src/hci-ble.c:9:33: fatal error: bluetooth/bluetooth.h: No such file or directory
 #include <bluetooth/bluetooth.h>
                                 ^
compilation terminated.
hci-ble.target.mk:81: recipe for target 'Release/obj.target/hci-ble/src/hci-ble.o' failed
make: *** [Release/obj.target/hci-ble/src/hci-ble.o] Error 1
make: Leaving directory '/home/bryce/boneyard/node_modules/blecat/node_modules/ble-swarm/node_modules/noble/build'
```
